### PR TITLE
Use Root Relative URLs when possible

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -24,7 +24,7 @@
       <ul>
         <li><a href="/">Home</a></li>
         <li><a href="/download" class="cc-active">Download</a></li>
-        <li><a href="https://www.whonix.org/wiki/Documentation">Wiki</a></li>
+        <li><a href="/wiki/Documentation">Wiki</a></li>
         <li><a href="https://forums.whonix.org/">Forum</a></li>
         <li><a href="/blog">News</a></li>
       </ul>
@@ -50,21 +50,21 @@
 			<div class="quad clearfix">
 			<div>
 				<div class="portfolio-block">
-					<a href="https://whonix.org/wiki/Windows"><img width="350" height="200" src="/img/win10.png" alt="Windows" class="editable"></a>
+					<a href="/wiki/Windows"><img width="350" height="200" src="/img/win10.png" alt="Windows" class="editable"></a>
 					<h4 class="editable">Windows</h4>
 				</div>
 			</div>
 
 			<div>
 				<div class="portfolio-block">
-					<a href="https://whonix.org/wiki/VirtualBox"><img width="350" height="150" src="/img/Whonix_Linux.png" alt="Linux" class="editable"></a>
+					<a href="/wiki/VirtualBox"><img width="350" height="150" src="/img/Whonix_Linux.png" alt="Linux" class="editable"></a>
 					<h4 class="editable">Linux</h4>
 				</div>
 			</div>
 
 			<div>
 				<div class="portfolio-block">
-					<a href="https://whonix.org/wiki/VirtualBox"><img width="350" height="150" src="/img/Whonix_OSX.png" alt="osx" class="editable"></a>
+					<a href="/wiki/VirtualBox"><img width="350" height="150" src="/img/Whonix_OSX.png" alt="osx" class="editable"></a>
 					<h4 class="editable">OS X</h4>
 				</div>
 			</div>
@@ -89,7 +89,7 @@
 
     <footer>
 		<div class="container">
-			<p><a href="https://www.whonix.org/wiki/Payments">Payments</a></p>
+			<p><a href="/wiki/Payments">Payments</a></p>
 		</div>
     </footer>
   </body>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
 <div class="alert">
   <span class="closebtn" onclick="this.parentElement.style.display='none';">&times;</span>
-  	<strong>We need your help!</strong> Whonix requires payments to stay alive. <a href="https://www.whonix.org/wiki/Payments">Do your part!</a>
+  <strong>We need your help!</strong> Whonix requires payments to stay alive. <a href="/wiki/Payments">Do your part!</a>
 </div>
 
 <section class="hero">
@@ -28,7 +28,7 @@
       <ul>
         <li><a href="/" class="cc-active">Home</a></li>
         <li><a href="/download">Download</a></li>
-        <li><a href="https://www.whonix.org/wiki/Documentation">Wiki</a></li>
+        <li><a href="/wiki/Documentation">Wiki</a></li>
         <li><a href="https://forums.whonix.org/">Forum</a></li>
         <li><a href="/blog">News</a></li>
       </ul>
@@ -117,7 +117,7 @@
 
     <footer>
 		<div class="container">
-			<p><a> </a><a href="https://www.whonix.org/wiki/Payments">Payments</a><a> </a></p>
+			<p><a> </a><a href="/wiki/Payments">Payments</a><a> </a></p>
 		</div>
     </footer>
   </body>


### PR DESCRIPTION
Note that `<li><a href="https://forums.whonix.org/">Forum</a></li>` still uses absolute path because its root is `forums.whonix.org`, not `www.whonix.org`.

Thanks to TNT_BOM_BOM for reporting this: http://forums.whonix.org/t/fixing-onion-v3-links-to-onion-main-page/5068