### PR TITLE
whonix.org/blog -> forum.whonix.org/c/news

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -26,7 +26,7 @@
         <li><a href="/download" class="cc-active">Download</a></li>
         <li><a href="/wiki/Documentation">Wiki</a></li>
         <li><a href="https://forums.whonix.org/">Forum</a></li>
-        <li><a href="/blog">News</a></li>
+        <li><a href="https://forums.whonix.org/c/news">News</a></li>
       </ul>
     </nav>
   </div>

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
         <li><a href="/download">Download</a></li>
         <li><a href="/wiki/Documentation">Wiki</a></li>
         <li><a href="https://forums.whonix.org/">Forum</a></li>
-        <li><a href="/blog">News</a></li>
+        <li><a href="https://forums.whonix.org/c/news">News</a></li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
As discussed on: https://forums.whonix.org/t/replacing-whonix-wordpress-blog-https-www-whonix-org-blog/5351/7