### PR TITLE
Wrap the protocol check in an isset() 

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,9 @@
 <?php
-$protocol = $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ? 'https://' : 'http://';
+if(isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+  $protocol = $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ? 'https://' : 'http://';
+} else {
+  $protocol = 'http://';
+}
 $host = str_replace('www.', '', $_SERVER['HTTP_HOST']);
 ?>
 <!DOCTYPE html>


### PR DESCRIPTION
in case the X_FORWARDED_PROTO header is not present (it actually isn't, when under .onion), to avoid noisy warning in logs