### PR TITLE
Change link to Qubes install doc

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -71,7 +71,7 @@
 
 			<div>
 				<div class="portfolio-block">
-					<a href="https://www.qubes-os.org/doc/whonix/install/"><img width="350" height="200" src="/img/qubes.png" alt="Qubes" class="editable"></a>
+					<a href="wiki/Qubes/Install"><img width="350" height="200" src="/img/qubes.png" alt="Qubes" class="editable"></a>
 					<h4 class="editable">Qubes</h4>
 				</div>
 			</div>


### PR DESCRIPTION
Already applied trivial change on server

https://forums.whonix.org/t/whonix-qubes-in-homepage-directing-to-404-page-not-found/5921