### PR TITLE
Add Onion-Location meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@ See the file COPYING for copying conditions.
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
     <meta name="description" content="Free, Open Source, Kicksecure ™ Security Hardened Linux Distribution, designed for advanced online privacy, Live or Non-Live (Persistent) Mode." />
     <meta name="author" content="Whonix" />
+    <meta http-equiv="onion-location" content="http://dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@Whonix" />
     <meta name="twitter:creator" content="@Whonix" />


### PR DESCRIPTION
Starting with the release of [Tor Browser 9.5](https://blog.torproject.org/new-release-tor-browser-95), websites can have their alternate .onion addresses advertised to Tor desktop users who have the 'Onion Location' option enabled.

Sites that add the .onion address advertisement HTTP header can prompt their visitors to switch to a version delivered using the Onion service for improved security.

Final result:
![ezgif-2-354636e604ed](https://user-images.githubusercontent.com/46527252/83661669-bced5700-a5c6-11ea-9416-789ff30e52ef.gif)
