### PR TITLE
Remove TorProject.org reference.

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,20 +150,6 @@ See the file COPYING for copying conditions.
             </a>
         </div>
         <div class="third">
-            <a href="https://web.archive.org/web/20180625051536/https://blog.torproject.org/tor-heart-whonix" target="_blank" rel="noopener">
-                <img src="/w/images/thumb/4/44/2880px-Tor-logo-2011-flat.svg.png/470px-2880px-Tor-logo-2011-flat.svg.png" width=212 height=128 alt="The Tor Project Logo" />
-            </a>
-            <a href="https://web.archive.org/web/20180625051536/https://blog.torproject.org/tor-heart-whonix" target="_blank" rel="noopener">
-                ”Whonix is a privacy ecosystem that utilizes compartmentalization to
-                provide a private, leak-resistant environment for many desktop
-                computing activities. Whonix helps users use their favorite desktop
-                applications anonymously.”
-            </a>
-            <p>The Tor
-            <a href="https://2019.www.torproject.org/docs/trademark-faq.html.en" target="_blank" rel="noopener">&reg;</a> Project
-            </p>
-        </div>
-        <div class="third">
             <a href="https://twitter.com/Snowden" target="_blank" rel="noopener">
                 <img src="/w/images/2/20/Expert-edward-snowden.jpg" width=128 height=128 alt="Edward Snowden" />
             </a>


### PR DESCRIPTION
Hello,

Kindly remove the references to the old TorProject.org blog post. Linking to the archived version of this article to avoid showing the updated message of August 2020 is hardly something anybody benefits from.

We think it would better if the Whonix project simply removes the reference.

Thank you!

All the best,
Alex (on behalf of the Tor Project Community Council).